### PR TITLE
Correct filename case in #include directives

### DIFF
--- a/epd1in54/epdif.cpp
+++ b/epd1in54/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd1in54/epdif.h
+++ b/epd1in54/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd1in54b/epdif.cpp
+++ b/epd1in54b/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd1in54b/epdif.h
+++ b/epd1in54b/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd1in54c/epdif.cpp
+++ b/epd1in54c/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd1in54c/epdif.h
+++ b/epd1in54c/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd2in13/epdif.cpp
+++ b/epd2in13/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd2in13/epdif.h
+++ b/epd2in13/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd2in13b/epdif.cpp
+++ b/epd2in13b/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd2in13b/epdif.h
+++ b/epd2in13b/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd2in7/epdif.cpp
+++ b/epd2in7/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd2in7/epdif.h
+++ b/epd2in7/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd2in7b/epdif.cpp
+++ b/epd2in7b/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd2in7b/epdif.h
+++ b/epd2in7b/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd2in9/epdif.cpp
+++ b/epd2in9/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd2in9/epdif.h
+++ b/epd2in9/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd2in9b/epdif.cpp
+++ b/epd2in9b/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd2in9b/epdif.h
+++ b/epd2in9b/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd4in2/epdif.cpp
+++ b/epd4in2/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd4in2/epdif.h
+++ b/epd4in2/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd4in2b/epdif.cpp
+++ b/epd4in2b/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd4in2b/epdif.h
+++ b/epd4in2b/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd7in5/epdif.cpp
+++ b/epd7in5/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd7in5/epdif.h
+++ b/epd7in5/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)

--- a/epd7in5b/epdif.cpp
+++ b/epd7in5b/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/epd7in5b/epdif.h
+++ b/epd7in5b/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition for ESP8266 (e.g. NodeMCU)
 // Connect display CLK signal to GPIO 14 (Node MCU pin D5)


### PR DESCRIPTION
On a filename case-sensitive operating system like Linux, use of the incorrect filename case in an #include directive causes compilation to fail:
```
No such file or directory
```